### PR TITLE
Merge staging to draft - Dependabot Bump (#86)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           cat $logsPath | grep Launching
       - name: Archive server logs if failed
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: server-logs
           path: finish/target/liberty/wlp/usr/servers/defaultServer/logs/

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -38,19 +38,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.3</version>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.9.Final</version>
+            <version>6.2.10.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.9.Final</version>
+            <version>6.2.10.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -67,18 +67,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.1</version>
             </plugin>
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.10.3</version>
+                <version>3.11.1</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <http.port>${liberty.var.default.http.port}</http.port>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -38,19 +38,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.3</version>
+            <version>5.11.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.9.Final</version>
+            <version>6.2.10.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.9.Final</version>
+            <version>6.2.10.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -67,18 +67,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.1</version>
             </plugin>
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.10.3</version>
+                <version>3.11.1</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.5.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <http.port>${liberty.var.default.http.port}</http.port>


### PR DESCRIPTION
* Dependabot Bump (#74)

* Bump org.apache.maven.plugins:maven-failsafe-plugin in /start

Bumps [org.apache.maven.plugins:maven-failsafe-plugin](https://github.com/apache/maven-surefire) from 3.3.1 to 3.5.0.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.1...surefire-3.5.0)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-minor ...



* Bump org.jboss.resteasy:resteasy-json-binding-provider in /start

Bumps org.jboss.resteasy:resteasy-json-binding-provider from 6.2.9.Final to 6.2.10.Final.

---
updated-dependencies:
- dependency-name: org.jboss.resteasy:resteasy-json-binding-provider dependency-type: direct:development update-type: version-update:semver-patch ...



* Bump org.junit.jupiter:junit-jupiter from 5.10.3 to 5.11.0 in /start

Bumps [org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit5) from 5.10.3 to 5.11.0.
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.10.3...r5.11.0)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter dependency-type: direct:development update-type: version-update:semver-minor ...



* Bump org.apache.maven.plugins:maven-surefire-plugin in /start

Bumps [org.apache.maven.plugins:maven-surefire-plugin](https://github.com/apache/maven-surefire) from 3.3.1 to 3.5.0.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.1...surefire-3.5.0)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-type: direct:production update-type: version-update:semver-minor ...



* Bump org.jboss.resteasy:resteasy-client in /start

Bumps [org.jboss.resteasy:resteasy-client](https://github.com/resteasy/resteasy) from 6.2.9.Final to 6.2.10.Final.
- [Release notes](https://github.com/resteasy/resteasy/releases)
- [Commits](https://github.com/resteasy/resteasy/compare/6.2.9.Final...6.2.10.Final)

---
updated-dependencies:
- dependency-name: org.jboss.resteasy:resteasy-client dependency-type: direct:development update-type: version-update:semver-patch ...



* Bump org.apache.maven.plugins:maven-surefire-plugin in /finish

Bumps [org.apache.maven.plugins:maven-surefire-plugin](https://github.com/apache/maven-surefire) from 3.3.1 to 3.5.0.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.1...surefire-3.5.0)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-type: direct:production update-type: version-update:semver-minor ...



* Bump org.junit.jupiter:junit-jupiter from 5.10.3 to 5.11.0 in /finish

Bumps [org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit5) from 5.10.3 to 5.11.0.
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.10.3...r5.11.0)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter dependency-type: direct:development update-type: version-update:semver-minor ...



* Bump org.apache.maven.plugins:maven-failsafe-plugin in /finish

Bumps [org.apache.maven.plugins:maven-failsafe-plugin](https://github.com/apache/maven-surefire) from 3.3.1 to 3.5.0.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.3.1...surefire-3.5.0)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-minor ...



* Bump org.jboss.resteasy:resteasy-json-binding-provider in /finish

Bumps org.jboss.resteasy:resteasy-json-binding-provider from 6.2.9.Final to 6.2.10.Final.

---
updated-dependencies:
- dependency-name: org.jboss.resteasy:resteasy-json-binding-provider dependency-type: direct:development update-type: version-update:semver-patch ...



* Bump org.jboss.resteasy:resteasy-client in /finish

Bumps [org.jboss.resteasy:resteasy-client](https://github.com/resteasy/resteasy) from 6.2.9.Final to 6.2.10.Final.
- [Release notes](https://github.com/resteasy/resteasy/releases)
- [Commits](https://github.com/resteasy/resteasy/compare/6.2.9.Final...6.2.10.Final)

---
updated-dependencies:
- dependency-name: org.jboss.resteasy:resteasy-client dependency-type: direct:development update-type: version-update:semver-patch ...



* update upload-artifact to v4 and restore reactive dependencies



---------





* Dependabot Bump (#77)

* Bump org.junit.jupiter:junit-jupiter from 5.11.0 to 5.11.1 in /start

Bumps [org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit5) from 5.11.0 to 5.11.1.
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.11.0...r5.11.1)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter dependency-type: direct:development update-type: version-update:semver-patch ...



* Bump org.junit.jupiter:junit-jupiter from 5.11.0 to 5.11.1 in /finish

Bumps [org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit5) from 5.11.0 to 5.11.1.
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.11.0...r5.11.1)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter dependency-type: direct:development update-type: version-update:semver-patch ...



---------




* Bump org.apache.maven.plugins:maven-failsafe-plugin in /start

Bumps [org.apache.maven.plugins:maven-failsafe-plugin](https://github.com/apache/maven-surefire) from 3.5.0 to 3.5.1.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.5.0...surefire-3.5.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-patch ...



* Bump org.junit.jupiter:junit-jupiter from 5.11.1 to 5.11.3 in /start

Bumps [org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit5) from 5.11.1 to 5.11.3.
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.11.1...r5.11.3)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter dependency-type: direct:development update-type: version-update:semver-patch ...



* Bump io.openliberty.tools:liberty-maven-plugin in /start

Bumps [io.openliberty.tools:liberty-maven-plugin](https://github.com/OpenLiberty/ci.maven) from 3.10.3 to 3.11.1.
- [Release notes](https://github.com/OpenLiberty/ci.maven/releases)
- [Commits](https://github.com/OpenLiberty/ci.maven/compare/liberty-maven-3.10.3...liberty-maven-3.11.1)

---
updated-dependencies:
- dependency-name: io.openliberty.tools:liberty-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor ...



* Bump org.apache.maven.plugins:maven-surefire-plugin in /start

Bumps [org.apache.maven.plugins:maven-surefire-plugin](https://github.com/apache/maven-surefire) from 3.5.0 to 3.5.1.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.5.0...surefire-3.5.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-type: direct:production update-type: version-update:semver-patch ...



* Bump org.junit.jupiter:junit-jupiter from 5.11.1 to 5.11.3 in /finish

Bumps [org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit5) from 5.11.1 to 5.11.3.
- [Release notes](https://github.com/junit-team/junit5/releases)
- [Commits](https://github.com/junit-team/junit5/compare/r5.11.1...r5.11.3)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter dependency-type: direct:development update-type: version-update:semver-patch ...



* Bump org.apache.maven.plugins:maven-surefire-plugin in /finish

Bumps [org.apache.maven.plugins:maven-surefire-plugin](https://github.com/apache/maven-surefire) from 3.5.0 to 3.5.1.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.5.0...surefire-3.5.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-surefire-plugin dependency-type: direct:production update-type: version-update:semver-patch ...



* Bump org.apache.maven.plugins:maven-failsafe-plugin in /finish

Bumps [org.apache.maven.plugins:maven-failsafe-plugin](https://github.com/apache/maven-surefire) from 3.5.0 to 3.5.1.
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.5.0...surefire-3.5.1)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-failsafe-plugin dependency-type: direct:production update-type: version-update:semver-patch ...



* Bump io.openliberty.tools:liberty-maven-plugin in /finish

Bumps [io.openliberty.tools:liberty-maven-plugin](https://github.com/OpenLiberty/ci.maven) from 3.10.3 to 3.11.1.
- [Release notes](https://github.com/OpenLiberty/ci.maven/releases)
- [Commits](https://github.com/OpenLiberty/ci.maven/compare/liberty-maven-3.10.3...liberty-maven-3.11.1)

---
updated-dependencies:
- dependency-name: io.openliberty.tools:liberty-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor ...



---------